### PR TITLE
add backbone routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,57 @@ var Orchestra = require('orchestra');
 var soundChannel = Orchestra.Radio.channel('sound');
 ```
 
+### Backbone.Routing
+[repo](https://github.com/thejameskyle/backbone-routing)
+
+_"Simple router and route classes for Backbone."_
+
+Backbone.Routing exposes 2 classes: `Router` and `Route`. These class are available via Orchestra using
+the following syntax:
+
+```
+var Orchestra = require('orchestra');
+
+var IndexRoute = Orchestra.Route.extend({
+  initialize(options) {
+    this.foo = options.foo;
+  },
+
+  fetch: function() {
+    // fetch model/collection
+  },
+
+  render: function() {
+    // render a view, called after `fetch`
+  },
+
+  destroy: function() {
+    // clean up view
+  }
+});
+
+var Router = Orchestra.Router.extend({
+  initialize: function(options) {
+    // do stuff on init
+    this.foo = options.foo;
+  },
+
+  onBeforeEnter: function() {
+    // do something before entering any of the routes, e.g. check authentication, highlight navbar
+  },
+
+  routes: {
+    '': 'index'
+  },
+
+  index: function() {
+    return new IndexRoute({
+      foo: this.foo
+    });
+  }
+});
+```
+
 ### Backbone.Cocktail
 [repo](https://github.com/onsi/cocktail)
 

--- a/package.json
+++ b/package.json
@@ -19,16 +19,17 @@
   "main": "lib/index.js",
   "dependencies": {
     "backbone": "1.2.1",
+    "backbone-routing": "^0.2.0",
     "backbone.cocktail": "0.5.10",
     "backbone.marionette": "^2.4.2",
     "backbone.radio": "^1.0.0",
     "backbone.stickit": "^0.8.0",
     "hammerjs": "^2.0.4",
+    "handlebars": "~1.3.0",
     "i18next-client": "^1.7.4",
     "jquery": "2.1.1",
     "lodash": "^3.7.0",
     "moment": "^2.8.3",
-    "handlebars": "~1.3.0",
     "numeral": "^1.5.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import $ from 'jquery';
 import _ from 'lodash';
 import Backbone from 'backbone';
+import {Route, Router} from 'backbone-routing';
 import Cocktail from 'backbone.cocktail';
 import Radio from 'backbone.radio';
 import Collection from './mvc/collection';
@@ -35,6 +36,8 @@ _.extend(Orchestra, {
   $,
   Radio,
   Cocktail,
+  Route,
+  Router,
   Collection,
   Currency,
   LocalStorage,


### PR DESCRIPTION
Backbone's Router is fairly bog standard and in most applications needs a lot of work until it is fit for purpose. Backbone-routing is a great library by @thejameskyle which extends Backbone.Router and gives it some really handy features such as:

* Callbacks to catch entry into a route and cancel entry if necessary (authentication/authorisation).
* Perform common tasks such as fetch data and render a view per route).