### PR TITLE
add backbone.storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,42 @@ var Orchestra = require('orchestra');
 var soundChannel = Orchestra.Radio.channel('sound');
 ```
 
+### Backbone.Storage
+[repo](https://github.com/thejameskyle/backbone.storage)
+
+_"A simple storage class for Backbone Models and Collections."_
+
+Backbone Storage combines Backbone Models and Collections into a single, easy to use API. To access the Storage class in Orchestra, use the following API:
+
+```
+var Orchestra = require('orchestra');
+var Book = require('./model)';
+var Books = require('./collection');
+
+var BookStore = Orchestra.Storage.extend({
+  model: Book,
+  collection: Books
+});
+
+var bookStore = new BookStore();
+
+// get a single book
+bookStore.find(1).then(model => {
+  model.get('name'); // >> A Tale of Two Cities
+});
+
+// get all books
+bookStore.findAll().then(collection => {
+  collection.length; // >> 10
+});
+
+// save a book to the server
+var book = new Book({ name: 'Lolita' });
+bookStore.save(book).then(model => {
+  model.id; // >> 11
+});
+```
+
 ### Backbone.Cocktail
 [repo](https://github.com/onsi/cocktail)
 

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "backbone.marionette": "^2.4.2",
     "backbone.radio": "^1.0.0",
     "backbone.stickit": "^0.8.0",
+    "backbone.storage": "^0.1.0",
     "hammerjs": "^2.0.4",
+    "handlebars": "~1.3.0",
     "i18next-client": "^1.7.4",
     "jquery": "2.1.1",
     "lodash": "^3.7.0",
     "moment": "^2.8.3",
-    "handlebars": "~1.3.0",
     "numeral": "^1.5.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import Backbone from 'backbone';
 import Cocktail from 'backbone.cocktail';
 import Radio from 'backbone.radio';
+import Storage from 'backbone.storage';
 import Collection from './mvc/collection';
 import Currency from './helpers/currency';
 import LocalStorage from './helpers/localStorage';
@@ -34,6 +35,7 @@ _.extend(Orchestra, {
   _,
   $,
   Radio,
+  Storage,
   Cocktail,
   Collection,
   Currency,


### PR DESCRIPTION
A storage library created by @thejameskyle. Makes great use of promises and works great alongside Backbone.Routing. A key ingredient to the wires architecture we'd like to promote.