### PR TITLE
adding rollup support to package.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
       "babelify"
     ]
   },
-  "browser": "src/index.js"
+  "browser": "src/index.js",
+  "jsnext:main": "src/index.js"
 }


### PR DESCRIPTION
adding a jsnext:main entry to package.json sp that ES6 can be used easily in electron apps, see https://github.com/rollup/rollup/wiki/jsnext:main