### PR TITLE
Allow colons in translated strings

### DIFF
--- a/src/helpers/translate.js
+++ b/src/helpers/translate.js
@@ -41,6 +41,8 @@ class TranslateHelpers {
     i18next
       .use(sprintf)
       .init({
+        nsSeparator: false,
+        keySeparator: false,
         lng: locale,
         resources: resources[locale]
       }, (err, translate) => {

--- a/tests/fixtures/translate/translate.json
+++ b/tests/fixtures/translate/translate.json
@@ -15,7 +15,8 @@
 				"helloWorld": "Hello World!",
 				"buyNTickets": "Buy %d tickets?",
 				"day": "day",
-				"day_plural": "days"
+				"day_plural": "days",
+				"error_message": "There was a problem: could not connect"
 			}
 		}
 	}

--- a/tests/spec/helpers/translate-spec.js
+++ b/tests/spec/helpers/translate-spec.js
@@ -87,6 +87,10 @@ describe('Translate Helper', function() {
 			expect(translateHelper.translate('helloWorld')).to.eql('Hello World!');
 		});
 
+		it('should translate a key with value containing colons correctly', function() {
+			expect(translateHelper.translate('error_message')).to.eql('There was a problem: could not connect');
+		});
+
 		it('should translate i18Key correctly with the count number supplied', function() {
 			expect(translateHelper.translate('day', {count: 2})).to.eql('days');
 		});


### PR DESCRIPTION
- Fixed an issue where strings with colons would get cut
{
 foo: "foo:bar"
}
translate('foo') would return bar